### PR TITLE
Only assign intentionally passed event data values

### DIFF
--- a/flipsnap.js
+++ b/flipsnap.js
@@ -497,7 +497,9 @@ Flipsnap.prototype._triggerEvent = function(type, bubbles, cancelable, data) {
 
   if (data) {
     for (var d in data) {
-      ev[d] = data[d];
+      if (data.hasOwnProperty(d)) {
+        ev[d] = data[d];
+      }
     }
   }
 


### PR DESCRIPTION
Just a simple change, but should prevent someone's heartache in the future.
