### PR TITLE
if number of swipable items is zero, Flipsnap has not worked

### DIFF
--- a/flipsnap.js
+++ b/flipsnap.js
@@ -239,7 +239,10 @@ Flipsnap.prototype.moveToPoint = function(point, transitionDuration) {
     point = self.currentPoint;
   }
 
-  if (point < 0) {
+  if (self._maxPoint <= -1) {
+    self.currentPoint = -1;
+  }
+  else if (point < 0) {
     self.currentPoint = 0;
   }
   else if (point > self._maxPoint) {


### PR DESCRIPTION
if number of swipable items is zero, Flipsnap has not worked. i fixed the issue.
the issue might cause after `instance.refresh()`

内容が何もない時、うまく動いていませんでした。
この問題は、AjaxなどでDOM操作後に`instance.refresh()`をするなどで起こりえます。
