### PR TITLE
use touch locus’ angle to decide whether to stop the browser default scrolling behavior

### DIFF
--- a/flipsnap.js
+++ b/flipsnap.js
@@ -395,7 +395,6 @@ Flipsnap.prototype._touchMove = function(event) {
     if (triangle.z > distanceThreshold) {
       if (getAngle(triangle) > angleThrehold) {
         event.preventDefault();
-        event.stopPropagation();
         self.moveReady = true;
         self.element.addEventListener('click', self, true);
       }


### PR DESCRIPTION
"js-flipsnap" use the x-axis and y-axis displacement to determine whether to prevent the browser's default scrolling.
But when you slide up and down quickly, often trigger flipsnap swiping, not browser's default scrolling.
Determine user behavior with touch track is accurater.
![img_0206](https://f.cloud.github.com/assets/436305/1590018/1cc0cc8c-5283-11e3-9763-28ca2013ab42.JPG)
