### PR TITLE
Cancel running animation when moveToPoint() is called.

### DIFF
--- a/flipsnap.js
+++ b/flipsnap.js
@@ -119,6 +119,7 @@ Flipsnap.prototype.init = function(element, opts) {
   self.currentPoint = 0;
   self.currentX = 0;
   self.animation = false;
+  self.timerId = null;
   self.use3d = support.transform3d;
   if (self.disable3d === true) {
     self.use3d = false;
@@ -469,11 +470,16 @@ Flipsnap.prototype._animate = function(x, transitionDuration) {
   var easing = function(time, duration) {
     return -(time /= duration) * (time - 2);
   };
-  var timer = setInterval(function() {
+
+  if (self.timerId) {
+    clearInterval(self.timerId);
+  }
+  self.timerId = setInterval(function() {
     var time = new Date() - begin;
     var pos, now;
     if (time > duration) {
-      clearInterval(timer);
+      clearInterval(self.timerId);
+      self.timerId = null;
       now = to;
     }
     else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -246,6 +246,14 @@ describe('Flipsnap', function() {
           expect(this.spy.args[0][0])
             .to.have.property('transitionDuration', '100ms');
         });
+        it('call moveToPoint while the previous animation is running', function(done) {
+          f.moveToPoint(1, 200);
+          f.moveToPoint(2, 0);
+          setTimeout(function() {
+            expect(f.currentPoint).to.be(2);
+            done();
+          }, 300);
+        });
       });
 
       context('when no support cssAnimation', function() {
@@ -263,8 +271,18 @@ describe('Flipsnap', function() {
           expect(this.spy.args[0][1])
             .to.be('100ms');
         });
+        it('call moveToPoint while the previous animation is running', function(done) {
+          f.moveToPoint(1, 200);
+          f.moveToPoint(2, 0);
+          setTimeout(function() {
+            expect(f.currentPoint).to.be(2);
+            expect(f.element.style.left).to.be('-200px');
+            done();
+          }, 300);
+        });
       });
     });
+
   });
 
   describe('Flip Events', function() {


### PR DESCRIPTION
This change fixes problem where the previous animation unintendedly
overrides new position. The problem typically occurd in IE9 with the
code like the following:

    // Animates to the first position with default duration (350ms).
    var flipsnap = Flipsnap('.flipsnap');

    // Move to the position immediately.
    flipsnap.moveToPoint(3, 0);

    // Now the third page should be shown, but the first page is shown.

Note that this change has effects only if the browser doesn't support
CSS animation.