### PR TITLE
Add defaultPoint option

### DIFF
--- a/flipsnap.js
+++ b/flipsnap.js
@@ -143,7 +143,7 @@ Flipsnap.prototype.init = function(element, opts) {
   }
 
   // initilize
-  self.refresh();
+  self.refresh(0);
 
   eventTypes.forEach(function(type) {
     self.element.addEventListener(events.start[type], self, false);
@@ -173,7 +173,7 @@ Flipsnap.prototype.handleEvent = function(event) {
   }
 };
 
-Flipsnap.prototype.refresh = function() {
+Flipsnap.prototype.refresh = function(transitionDuration) {
   var self = this;
 
   // setting max point
@@ -209,7 +209,7 @@ Flipsnap.prototype.refresh = function() {
   // setting maxX
   self._maxX = -self._distance * self._maxPoint;
 
-  self.moveToPoint(undefined, 0);
+  self.moveToPoint(undefined, transitionDuration);
 };
 
 Flipsnap.prototype.hasNext = function() {

--- a/flipsnap.js
+++ b/flipsnap.js
@@ -110,13 +110,14 @@ Flipsnap.prototype.init = function(element, opts) {
   opts = opts || {};
   self.distance = opts.distance;
   self.maxPoint = opts.maxPoint;
+  self.defaultPoint = opts.defaultPoint || 0;
   self.disableTouch = (opts.disableTouch === undefined) ? false : opts.disableTouch;
   self.disable3d = (opts.disable3d === undefined) ? false : opts.disable3d;
   self.transitionDuration = (opts.transitionDuration === undefined) ? '350ms' : opts.transitionDuration + 'ms';
   self.threshold = opts.threshold || 0;
 
   // set property
-  self.currentPoint = 0;
+  self.currentPoint = self.defaultPoint;
   self.currentX = 0;
   self.animation = false;
   self.timerId = null;
@@ -208,7 +209,7 @@ Flipsnap.prototype.refresh = function() {
   // setting maxX
   self._maxX = -self._distance * self._maxPoint;
 
-  self.moveToPoint();
+  self.moveToPoint(undefined, 0);
 };
 
 Flipsnap.prototype.hasNext = function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -97,6 +97,29 @@ describe('Flipsnap', function() {
       });
     });
   });
+  
+  describe('defaultPoint', function() {
+    context('when set defaultPoint to 0', function() {
+      it('should set currentPoint to 0', function() {
+        var f = Flipsnap($(html).get(0), { defaultPoint: 0 });
+        expect(f.currentPoint).to.be(0);
+      });
+    });
+
+    context('when set defaultPoint to 1', function() {
+      it('should set currentPoint to 1', function() {
+        var f = Flipsnap($(html).get(0), { defaultPoint: 1 });
+        expect(f.currentPoint).to.be(1);
+      });
+    });
+
+    context('when dont set defaultPoint', function() {
+      it('should set currentPoint to 0', function() {
+        var f = Flipsnap($(html).get(0));
+        expect(f.currentPoint).to.be(0);
+      });
+    });
+  });
 
   describe('#hasNext', function() {
     context('when has next element', function() {


### PR DESCRIPTION
Added an option (and related tests) to allow for the specification of a default point to be used at initialization. Default behavior is to work as before.

An example use case might be a calendar that allows swiping to scan months forward and back, but with a limited range of selectable dates. This would allow for starting in the current month instead of the earliest month. Also useful for image sliders that might want to start on a random slide, or for mobile where a user could swipe left or right on content to view different options.
